### PR TITLE
Fixing set size typo

### DIFF
--- a/sets.js
+++ b/sets.js
@@ -1,5 +1,5 @@
 /**
-  * Set is a collection of unique values. A Set can be iterated in order of 
+  * Set is a collection of unique values. A Set can be iterated in order of
   * insertion of its elements.
   */
 
@@ -11,6 +11,6 @@ foo.add("three");
 
 foo.has(1); // true
 
-foo.size(); // 3
+foo.size; // 3
 
 foo.delete(2); // removes 2 from foo


### PR DESCRIPTION
`set.size()` is not actually a thing, the proper syntax is `set.size`
