### PR TITLE
ES5 Equivs

### DIFF
--- a/arrow.js
+++ b/arrow.js
@@ -10,7 +10,7 @@ let foo = ["Hello", "World"];
 let bar = foo.map(x => x.length);
 
 // ES5
-let bar = foo.map(function(x) { return x.length; });
+var bar = foo.map(function(x) { return x.length; });
 
 //multiline functions require curly braces
 //no arguments expect parenthesis
@@ -20,15 +20,15 @@ let foobar = () => {
 };
 
 // ES5 
-let foobar = function() {
+var foobar = function() {
     console.log("Hello");
     console.log("World");
 }
 
-//Returning onbject literal
+//Returning onbject literal. Requires Brackets.
 let quux = () => ({ "myProp" : 123 });
 
 //ES5
-let quux = function() {
+var quux = function() {
     return { "myProp" : 123 };
 };

--- a/arrow.js
+++ b/arrow.js
@@ -2,14 +2,33 @@
   * Arrow functions have shorter syntax that function expression.
   * These functions also lexically bind `this` value and are always anonymous.
   */
-
-var foo = ["Hello", "World"];
+  
+let foo = ["Hello", "World"];
 
 //single arguments do not require parenthesis or curly braces.
-var bar = foo.map(x => x.length);
+//The return statement is implicit
+let bar = foo.map(x => x.length);
+
+// ES5
+let bar = foo.map(function(x) { return x.length; });
 
 //multiline functions require curly braces
 //no arguments expect parenthesis
-var foobar = () => {
-    console.log("Hello World")
+let foobar = () => {
+    console.log("Hello");
+    console.log("World");
+};
+
+// ES5 
+let foobar = function() {
+    console.log("Hello");
+    console.log("World");
 }
+
+//Returning onbject literal
+let quux = () => ({ "myProp" : 123 });
+
+//ES5
+let quux = function() {
+    return { "myProp" : 123 };
+};


### PR DESCRIPTION
Perhaps useful to have ES5 equivalents? Also example for case of returning object literal.
Used let for ES6 examples.
