### PR TITLE
Use lowercase for instance variables

### DIFF
--- a/class.js
+++ b/class.js
@@ -12,6 +12,6 @@ class Animal {
   }
 }
 
-var Simone = new Animal("cat", "meow");
+var simone = new Animal("cat", "meow");
 
-Simone.makeNoise(); // returns "The cat goes meow"
+simone.makeNoise(); // returns "The cat goes meow"


### PR DESCRIPTION
Just because you can use uppercase, doesn't mean you should.  

Various style guides would agree, for example: 
    https://github.com/airbnb/javascript#22.2
