### PR TITLE
Add space after 'The' in output

### DIFF
--- a/class.js
+++ b/class.js
@@ -8,7 +8,7 @@ class Animal {
   }
   
   makeNoise() {
-    return ('The' + this.type + ' goes ' + this.sound);
+    return ('The ' + this.type + ' goes ' + this.sound);
   }
 }
 


### PR DESCRIPTION
Currently, the output is : 

```
Thecat goes meow
```

Proposed change is : 

```
The cat goes meow
```
