### PR TITLE
Adding a native array method to rest-params.js

### DIFF
--- a/rest-params.js
+++ b/rest-params.js
@@ -8,3 +8,10 @@ function foo(...x){
 }
 
 foo(1, 2, 3, 4); // 4
+
+function bar(...y) {
+  // y has all native array methods
+  return y.pop();
+}
+
+bar(1, 2, 3); // 3


### PR DESCRIPTION
I thought it would be nice to point out that rest-params have native array methods since the one example shown demonstrates length which `arguments` also has even though it is not an array and only array-like.
