### PR TITLE
Improve arrow example

### DIFF
--- a/arrow.js
+++ b/arrow.js
@@ -32,3 +32,27 @@ let quux = () => ({ "myProp" : 123 });
 var quux = function() {
     return { "myProp" : 123 };
 };
+
+
+// lexical binding for `this`
+let bob = {
+  _name: "Bob",
+  _friends: [],
+  printFriends: function () {
+    this._friends.forEach(f => {
+      console.log(this._name + " knows " + f)
+    });
+  }
+};
+
+// ES5
+var bob = {
+  _name: "Bob",
+  _friends: [],
+  printFriends: function () {
+    var self = this;
+    this._friends.forEach(function (f) {
+      console.log(self._name + "knows " + f));
+    });
+  }
+};

--- a/arrow.js
+++ b/arrow.js
@@ -40,7 +40,7 @@ let bob = {
   _friends: [],
   printFriends: function () {
     this._friends.forEach(f => {
-      console.log(this._name + " knows " + f)
+      console.log(this._name + " knows " + f);
     });
   }
 };
@@ -52,7 +52,7 @@ var bob = {
   printFriends: function () {
     var self = this;
     this._friends.forEach(function (f) {
-      console.log(self._name + "knows " + f));
+      console.log(self._name + "knows " + f);
     });
   }
 };


### PR DESCRIPTION
Improves the arrow functions examples by demonstrating the lexical binding of `this` within arrow functions.
