### PR TITLE
destructuring assignment example without property value shorthand

### DIFF
--- a/destructuring-assignment.js
+++ b/destructuring-assignment.js
@@ -8,3 +8,7 @@ var [one, two, three] = foo;
 
 var {a, b} = {a:1, b:2};
 // a => 1, b => 2
+
+var {a: foo, b: bar} = {a: 1, b: 2};
+// foo => 1, bar => 2
+// console.log(a, b) => ReferenceError


### PR DESCRIPTION
Current example uses property value shorthand, which is little confusing for anyone new to es6.
This new example exactly shows how the object destructuring actually works.
